### PR TITLE
Feature/feed with action

### DIFF
--- a/src/main/java/com/adinstar/pangyo/constant/ViewModelName.java
+++ b/src/main/java/com/adinstar/pangyo/constant/ViewModelName.java
@@ -20,7 +20,6 @@ public class ViewModelName {
     public static final String COMMENT_FEED = "commentFeed";
 
     public static final String IS_LIKED = "isLiked";
-    public static final String LIKED_LIST = "likedList";
 
     public static final String POLLED_LIST = "polledList";
 

--- a/src/main/java/com/adinstar/pangyo/constant/ViewModelName.java
+++ b/src/main/java/com/adinstar/pangyo/constant/ViewModelName.java
@@ -13,6 +13,7 @@ public class ViewModelName {
 
     public static final String CAMPAIGN_CANDIDATE = "campaignCandidate";
     public static final String CAMPAIGN_CANDIDATE_LIST = "campaignCandidateList";
+    public static final String CAMPAIGN_CANDIDATE_FEED = "campaignCandidateFeed";
 
     public static final String POST = "post";
     public static final String POST_FEED = "postFeed";
@@ -20,8 +21,6 @@ public class ViewModelName {
     public static final String COMMENT_FEED = "commentFeed";
 
     public static final String IS_LIKED = "isLiked";
-
-    public static final String POLLED_LIST = "polledList";
 
     public static final String AD_EXECUTION_RULE = "adExecutionRule";
 }

--- a/src/main/java/com/adinstar/pangyo/controller/api/CampaignCandidateApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/CampaignCandidateApiController.java
@@ -25,7 +25,7 @@ public class CampaignCandidateApiController {
             @ApiImplicitParam(name = "starId", value = "campaignCandidate 의 starId", paramType = "query", required = true, dataType = "long"),
             @ApiImplicitParam(name = "page", value = "page number", paramType = "query", required = true, dataType = "int")
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Map.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = CampaignCandidateFeedResponse.class)})
     @RequestMapping(method = RequestMethod.GET)
     public CampaignCandidateFeedResponse getRunningList(@RequestParam long starId,
                                                         @RequestParam int page,
@@ -37,7 +37,7 @@ public class CampaignCandidateApiController {
     @ApiImplicitParams({
             @ApiImplicitParam(name = "campaignCandidate", value = "campaignCandidate object", paramType = "body", required = true, dataType = "CampaignCandidate")
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Map.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(method = RequestMethod.POST)
     @MustLogin
     public void add(@RequestBody CampaignCandidate campaignCandidate) {
@@ -48,7 +48,7 @@ public class CampaignCandidateApiController {
     @ApiImplicitParams({
             @ApiImplicitParam(name = "campaignCandidate", value = "campaignCandidate object", paramType = "body", required = true, dataType = "campaignCandidate")
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Map.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(method = RequestMethod.PUT)
     @MustLogin
     public void modify(@RequestBody CampaignCandidate campaignCandidate) {
@@ -59,7 +59,7 @@ public class CampaignCandidateApiController {
     @ApiImplicitParams({
             @ApiImplicitParam(name = "campaignCandidate", value = "campaignCandidate object", paramType = "body", required = true, dataType = "campaignCandidate")
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Map.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(value = "/{campaignCandidateId}", method = RequestMethod.DELETE)
     @MustLogin
     public void remove(@PathVariable("campaignCandidateId") long id) {

--- a/src/main/java/com/adinstar/pangyo/controller/api/CampaignCandidateApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/CampaignCandidateApiController.java
@@ -1,13 +1,15 @@
 package com.adinstar.pangyo.controller.api;
 
 import com.adinstar.pangyo.common.annotation.MustLogin;
+import com.adinstar.pangyo.constant.ViewModelName;
 import com.adinstar.pangyo.model.CampaignCandidate;
+import com.adinstar.pangyo.model.CampaignCandidateFeedResponse;
+import com.adinstar.pangyo.model.ViewerInfo;
 import com.adinstar.pangyo.service.CampaignCandidateService;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -25,8 +27,10 @@ public class CampaignCandidateApiController {
     })
     @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Map.class)})
     @RequestMapping(method = RequestMethod.GET)
-    public List<CampaignCandidate> getRunningList(@RequestParam long starId, @RequestParam int page) {
-        return campaignCandidateService.getRunningList(starId, Optional.of(page), Optional.empty());
+    public CampaignCandidateFeedResponse getRunningList(@RequestParam long starId,
+                                                        @RequestParam int page,
+                                                        @ModelAttribute(ViewModelName.VIEWER) ViewerInfo viewerInfo) {
+        return campaignCandidateService.getRunningList(starId, Optional.of(page), Optional.empty(), viewerInfo == null? null : viewerInfo.getId());
     }
 
     @ApiOperation("캠페인 후보군 등록하기")

--- a/src/main/java/com/adinstar/pangyo/controller/api/CommentApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/CommentApiController.java
@@ -1,8 +1,10 @@
 package com.adinstar.pangyo.controller.api;
 
 import com.adinstar.pangyo.constant.PangyoEnum;
+import com.adinstar.pangyo.constant.ViewModelName;
 import com.adinstar.pangyo.model.Comment;
-import com.adinstar.pangyo.model.FeedResponse;
+import com.adinstar.pangyo.model.CommentFeedResponse;
+import com.adinstar.pangyo.model.ViewerInfo;
 import com.adinstar.pangyo.service.CommentService;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,13 +25,14 @@ public class CommentApiController {
             @ApiImplicitParam(name="lastId", value="last post id", paramType="query", dataType="Long")
     })
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = FeedResponse.class)
+            @ApiResponse(code = 200, message = "OK", response = CommentFeedResponse.class)
     })
     @RequestMapping(value = "/{contentType}/{contentId}", method = RequestMethod.GET)
-    public FeedResponse<Comment> getList(@PathVariable("contentType") String contentType,
-                                         @PathVariable("contentId") long contentId,
-                                         @RequestParam(value = "lastId", required = false) Long lastId) {
-        return commentService.getList(PangyoEnum.ContentType.valueOf(contentType), contentId, Optional.ofNullable(lastId));
+    public CommentFeedResponse getList(@PathVariable("contentType") String contentType,
+                                       @PathVariable("contentId") long contentId,
+                                       @RequestParam(value = "lastId", required = false) Long lastId,
+                                       @ModelAttribute(ViewModelName.VIEWER) ViewerInfo viewerInfo) {
+        return commentService.getList(PangyoEnum.ContentType.valueOf(contentType), contentId, Optional.ofNullable(lastId), viewerInfo == null ? null : viewerInfo.getId());
     }
 
     @ApiOperation("addComment")

--- a/src/main/java/com/adinstar/pangyo/controller/api/LikeApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/LikeApiController.java
@@ -3,7 +3,6 @@ package com.adinstar.pangyo.controller.api;
 import com.adinstar.pangyo.common.annotation.MustLogin;
 import com.adinstar.pangyo.constant.PangyoEnum;
 import com.adinstar.pangyo.constant.ViewModelName;
-import com.adinstar.pangyo.model.FeedResponse;
 import com.adinstar.pangyo.model.ViewerInfo;
 import com.adinstar.pangyo.service.LikeService;
 import io.swagger.annotations.*;
@@ -22,7 +21,7 @@ public class LikeApiController {
             @ApiImplicitParam(name="contentType", value="content type", paramType="path", dataType="String"),
             @ApiImplicitParam(name="contentId", value="content id", paramType="path", dataType="Long"),
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = FeedResponse.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(value = "/{contentType}/{contentId}", method = RequestMethod.POST)
     @MustLogin
     public void add(@PathVariable("contentType") String contentType,
@@ -36,7 +35,7 @@ public class LikeApiController {
             @ApiImplicitParam(name="contentType", value="content type", paramType="path", dataType="String"),
             @ApiImplicitParam(name="contentId", value="content id", paramType="path", dataType="Long"),
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = FeedResponse.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(value = "/{contentType}/{contentId}", method = RequestMethod.DELETE)
     @MustLogin
     public void remove(@PathVariable("contentType") String contentType,

--- a/src/main/java/com/adinstar/pangyo/controller/api/PollApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/PollApiController.java
@@ -3,7 +3,6 @@ package com.adinstar.pangyo.controller.api;
 import com.adinstar.pangyo.common.annotation.MustLogin;
 import com.adinstar.pangyo.constant.PangyoEnum;
 import com.adinstar.pangyo.constant.ViewModelName;
-import com.adinstar.pangyo.model.FeedResponse;
 import com.adinstar.pangyo.model.ViewerInfo;
 import com.adinstar.pangyo.service.PollService;
 import io.swagger.annotations.*;
@@ -22,7 +21,7 @@ public class PollApiController {
             @ApiImplicitParam(name="contentType", value="content type", paramType="path", dataType="String"),
             @ApiImplicitParam(name="contentId", value="content id", paramType="path", dataType="Long"),
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = FeedResponse.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(value = "/{contentType}/{contentId}", method = RequestMethod.POST)
     @MustLogin
     public void add(@PathVariable("contentType") String contentType,
@@ -36,7 +35,7 @@ public class PollApiController {
             @ApiImplicitParam(name="contentType", value="content type", paramType="path", dataType="String"),
             @ApiImplicitParam(name="contentId", value="content id", paramType="path", dataType="Long"),
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = FeedResponse.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(value = "/{contentType}/{contentId}", method = RequestMethod.DELETE)
     @MustLogin
     public void remove(@PathVariable("contentType") String contentType,

--- a/src/main/java/com/adinstar/pangyo/controller/api/PostApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/PostApiController.java
@@ -2,8 +2,11 @@ package com.adinstar.pangyo.controller.api;
 
 
 import com.adinstar.pangyo.common.annotation.MustLogin;
+import com.adinstar.pangyo.constant.ViewModelName;
 import com.adinstar.pangyo.model.FeedResponse;
 import com.adinstar.pangyo.model.Post;
+import com.adinstar.pangyo.model.PostFeedResponse;
+import com.adinstar.pangyo.model.ViewerInfo;
 import com.adinstar.pangyo.service.PostService;
 import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,9 +31,10 @@ public class PostApiController {
             @ApiResponse(code = 200, message = "OK", response = FeedResponse.class)
     })
     @RequestMapping(method = RequestMethod.GET)
-    public FeedResponse<Post> getListByStarId(@RequestParam("starId") long starId,
-                                              @RequestParam(value = "lastId", required = false) Long lastId) {
-        return postService.getListByStarId(starId, Optional.ofNullable(lastId));
+    public PostFeedResponse getListByStarId(@RequestParam("starId") long starId,
+                                            @RequestParam(value = "lastId", required = false) Long lastId,
+                                            @ModelAttribute(ViewModelName.VIEWER) ViewerInfo viewerInfo) {
+        return postService.getListByStarId(starId, Optional.ofNullable(lastId), viewerInfo == null ? null : viewerInfo.getId());
     }
 
     @ApiOperation("getPost")

--- a/src/main/java/com/adinstar/pangyo/controller/api/PostApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/PostApiController.java
@@ -3,7 +3,6 @@ package com.adinstar.pangyo.controller.api;
 
 import com.adinstar.pangyo.common.annotation.MustLogin;
 import com.adinstar.pangyo.constant.ViewModelName;
-import com.adinstar.pangyo.model.FeedResponse;
 import com.adinstar.pangyo.model.Post;
 import com.adinstar.pangyo.model.PostFeedResponse;
 import com.adinstar.pangyo.model.ViewerInfo;
@@ -28,7 +27,7 @@ public class PostApiController {
             @ApiImplicitParam(name="lastId", value="last post id", paramType="query", dataType="Long")
     })
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = FeedResponse.class)
+            @ApiResponse(code = 200, message = "OK", response = PostFeedResponse.class)
     })
     @RequestMapping(method = RequestMethod.GET)
     public PostFeedResponse getListByStarId(@RequestParam("starId") long starId,
@@ -58,7 +57,7 @@ public class PostApiController {
             @ApiImplicitParam(name="post", value="post object", paramType="body", required=true, dataType="Post")
     })
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = Map.class)
+            @ApiResponse(code = 200, message = "OK")
     })
     @RequestMapping(method = RequestMethod.POST)
     @MustLogin
@@ -74,7 +73,7 @@ public class PostApiController {
             @ApiImplicitParam(name="post", value="post object", paramType="body", required=true, dataType="Post")
     })
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = Map.class)
+            @ApiResponse(code = 200, message = "OK")
     })
     @RequestMapping(method = RequestMethod.PUT)
     @MustLogin
@@ -87,7 +86,7 @@ public class PostApiController {
             @ApiImplicitParam(name="postId", value="post id", paramType="path", required=true, dataType="long")
     })
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = Map.class)
+            @ApiResponse(code = 200, message = "OK")
     })
     @RequestMapping(value = "/{postId}", method = RequestMethod.DELETE)
     @MustLogin

--- a/src/main/java/com/adinstar/pangyo/controller/api/StarApiController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/api/StarApiController.java
@@ -40,7 +40,7 @@ public class StarApiController {
     @ApiImplicitParams({
             @ApiImplicitParam(name="star", value="star object", paramType="body", required=true, dataType="Star")
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = FeedResponse.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(method = RequestMethod.POST)
     public void add(@RequestBody Star star) {
         starService.add(star);
@@ -51,7 +51,7 @@ public class StarApiController {
     @ApiImplicitParams({
             @ApiImplicitParam(name="star", value="star object", paramType="body", required=true, dataType="Star")
     })
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = FeedResponse.class)})
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
     @RequestMapping(method = RequestMethod.PUT)
     public void modify(@RequestBody Star star) {
         starService.modify(star);
@@ -74,7 +74,7 @@ public class StarApiController {
     @ApiImplicitParams({
             @ApiImplicitParam(name = "starId", value = "star Id", paramType = "path", dataType = "long")
     })
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Map.class)})
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK")})
     @RequestMapping(value = "/join/{starId}", method = RequestMethod.POST)
     @MustLogin
     public void joinedStar(@PathVariable("starId") long starId,
@@ -86,7 +86,7 @@ public class StarApiController {
     @ApiImplicitParams({
             @ApiImplicitParam(name = "starId", value = "star Id", paramType = "path", dataType = "long")
     })
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Map.class)})
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK")})
     @RequestMapping(value = "/join/{starId}", method = RequestMethod.DELETE)
     @MustLogin
     public void secededStar(@PathVariable("starId") long starId,

--- a/src/main/java/com/adinstar/pangyo/controller/view/FanClubController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/view/FanClubController.java
@@ -2,13 +2,9 @@ package com.adinstar.pangyo.controller.view;
 
 
 import com.adinstar.pangyo.common.annotation.MustLogin;
-import com.adinstar.pangyo.constant.PangyoEnum;
 import com.adinstar.pangyo.constant.ViewModelName;
-import com.adinstar.pangyo.model.FeedResponse;
 import com.adinstar.pangyo.model.ViewerInfo;
-import com.adinstar.pangyo.model.Post;
 import com.adinstar.pangyo.service.CampaignCandidateService;
-import com.adinstar.pangyo.service.LikeService;
 import com.adinstar.pangyo.service.PostService;
 import com.adinstar.pangyo.service.StarService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,10 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.adinstar.pangyo.constant.ViewModelName.*;
 
@@ -39,25 +32,15 @@ public class FanClubController {
     @Autowired
     private PostService postService;
 
-    @Autowired
-    private LikeService likeService;
-
     // checked !! :  팬클럽만 해당 내용을 읽을 수 있나요? 혹은 팬클럽만 글쓰고 투표할 수 있나요???
     @RequestMapping(value = {"", "/"}, method = RequestMethod.GET)
     @MustLogin
     public String getTopFeed(@PathVariable("starId") long starId,
                              @ModelAttribute(ViewModelName.VIEWER) ViewerInfo viewerInfo,
                              Model model) {
-        FeedResponse<Post> postFeedResponse = postService.getListByStarId(starId, Optional.empty());
-        List<Long> ids = postFeedResponse.getList().stream()
-                .map(Post::getId)
-                .collect(Collectors.toList());
-
         model.addAttribute(STAR, starService.getById(starId));
         model.addAttribute(CAMPAIGN_CANDIDATE_LIST, campaignCandidateService.getRunningList(starId, Optional.of(1), Optional.of(2)));
-        model.addAttribute(POST_FEED, postFeedResponse);
-        model.addAttribute(LIKED_LIST,
-                ids.size() == 0 ? new ArrayList<>() : likeService.getContentIdList(PangyoEnum.ContentType.POST, ids, viewerInfo.getId()));
+        model.addAttribute(POST_FEED, postService.getListByStarId(starId, Optional.empty(), viewerInfo == null ? null : viewerInfo.getId()));
 
         return "fanClub/list";  // 질문 : 로그인 한 유저만 list를 볼 수 있나요? +  팬클럽 회원만 list를 볼 수 있나요? url 따라오면 어디로 보내면 되나요?
     }

--- a/src/main/java/com/adinstar/pangyo/controller/view/FanClubController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/view/FanClubController.java
@@ -39,7 +39,7 @@ public class FanClubController {
                              @ModelAttribute(ViewModelName.VIEWER) ViewerInfo viewerInfo,
                              Model model) {
         model.addAttribute(STAR, starService.getById(starId));
-        model.addAttribute(CAMPAIGN_CANDIDATE_LIST, campaignCandidateService.getRunningList(starId, Optional.of(1), Optional.of(2)));
+        model.addAttribute(CAMPAIGN_CANDIDATE_LIST, campaignCandidateService.getRunningList(starId, Optional.of(1), Optional.of(2), null).getList());
         model.addAttribute(POST_FEED, postService.getListByStarId(starId, Optional.empty(), viewerInfo == null ? null : viewerInfo.getId()));
 
         return "fanClub/list";  // 질문 : 로그인 한 유저만 list를 볼 수 있나요? +  팬클럽 회원만 list를 볼 수 있나요? url 따라오면 어디로 보내면 되나요?

--- a/src/main/java/com/adinstar/pangyo/controller/view/fanClub/CampaignCandidateController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/view/fanClub/CampaignCandidateController.java
@@ -9,16 +9,13 @@ import com.adinstar.pangyo.model.CampaignCandidate;
 import com.adinstar.pangyo.model.ViewerInfo;
 import com.adinstar.pangyo.service.CampaignCandidateService;
 import com.adinstar.pangyo.service.ExecutionRuleService;
-import com.adinstar.pangyo.service.PollService;
 import com.adinstar.pangyo.service.StarService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.adinstar.pangyo.constant.ViewModelName.*;
 
@@ -33,23 +30,14 @@ public class CampaignCandidateController {
     private CampaignCandidateService campaignCandidateService;
 
     @Autowired
-    private PollService pollService;
-
-    @Autowired
     private ExecutionRuleService executionRuleService;
 
     @RequestMapping(value = {"", "/"}, method = RequestMethod.GET)
     public String getList(@PathVariable("starId") long starId,
                           @ModelAttribute(ViewModelName.VIEWER) ViewerInfo viewerInfo,
                           Model model) {
-        List<CampaignCandidate> campaignCandidateList = campaignCandidateService.getRunningList(starId, Optional.empty(), Optional.empty());
-        List<Long> ids = campaignCandidateList.stream()
-                .map(CampaignCandidate::getId)
-                .collect(Collectors.toList());
-
         model.addAttribute(STAR, starService.getById(starId));
-        model.addAttribute(CAMPAIGN_CANDIDATE_LIST, campaignCandidateList);
-        model.addAttribute(POLLED_LIST, pollService.getContentIdList(PangyoEnum.ContentType.CANDIDATE, ids, viewerInfo.getId()));
+        model.addAttribute(CAMPAIGN_CANDIDATE_FEED, campaignCandidateService.getRunningList(starId, Optional.empty(), Optional.empty(), viewerInfo == null ? null : viewerInfo.getId()));
         model.addAttribute(AD_EXECUTION_RULE, executionRuleService.getAdExecutionRuleByProgressExecuteRuleByType(PangyoEnum.ExecutionRuleType.CANDIDATE));
 
         return "fanClub/campaignCandidate/list";

--- a/src/main/java/com/adinstar/pangyo/controller/view/fanClub/PostController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/view/fanClub/PostController.java
@@ -45,7 +45,7 @@ public class PostController {
 
         model.addAttribute(POST, postService.getById(postId));
         model.addAttribute(COMMENT_FEED, commentService.getList(PangyoEnum.ContentType.POST, postId, Optional.empty(), viewerInfo == null ? null : viewerInfo.getId()));
-        model.addAttribute(IS_LIKED, likeService.isActioned(PangyoEnum.ContentType.POST, postId, viewerInfo.getId()));
+        model.addAttribute(IS_LIKED, viewerInfo != null && likeService.isActioned(PangyoEnum.ContentType.POST, postId, viewerInfo.getId()));
 
         return "fanClub/post/detail";
     }

--- a/src/main/java/com/adinstar/pangyo/controller/view/fanClub/PostController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/view/fanClub/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
         }
 
         model.addAttribute(POST, postService.getById(postId));
-        model.addAttribute(COMMENT_FEED, commentService.getList(PangyoEnum.ContentType.POST, postId, Optional.empty()));
+        model.addAttribute(COMMENT_FEED, commentService.getList(PangyoEnum.ContentType.POST, postId, Optional.empty(), viewerInfo == null ? null : viewerInfo.getId()));
         model.addAttribute(IS_LIKED, likeService.isActioned(PangyoEnum.ContentType.POST, postId, viewerInfo.getId()));
 
         return "fanClub/post/detail";

--- a/src/main/java/com/adinstar/pangyo/model/CampaignCandidate.java
+++ b/src/main/java/com/adinstar/pangyo/model/CampaignCandidate.java
@@ -4,7 +4,7 @@ import com.adinstar.pangyo.constant.PangyoEnum.*;
 import lombok.Data;
 
 @Data
-public class CampaignCandidate {
+public class CampaignCandidate implements FeedData {
     private long id;
     private long executeRuleId;
     private Star star;

--- a/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
+++ b/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
@@ -7,9 +7,15 @@ import java.util.List;
 @Data
 public class CampaignCandidateFeedResponse extends FeedResponse {
     private List<Long> pollList;
+    private int page;
 
-    public CampaignCandidateFeedResponse(List<CampaignCandidate> campaignCandidateList, int expactListSize, List<Long> pollList) {
+    public CampaignCandidateFeedResponse(List<CampaignCandidate> campaignCandidateList, int page, int expactListSize, List<Long> pollList) {
         super(campaignCandidateList, expactListSize);
+
+        this.page = page;
         this.pollList = pollList;
+
+        // 캠페인후보는 lastId 대신 page값 이용
+        this.setLastId(0);
     }
 }

--- a/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
+++ b/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
@@ -1,0 +1,15 @@
+package com.adinstar.pangyo.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CampaignCandidateFeedResponse extends FeedResponse {
+    private List<Long> pollList;
+
+    public CampaignCandidateFeedResponse(List<CampaignCandidate> campaignCandidateList, int expactListSize, List<Long> pollList) {
+        super(campaignCandidateList, expactListSize);
+        this.pollList = pollList;
+    }
+}

--- a/src/main/java/com/adinstar/pangyo/model/CommentFeedResponse.java
+++ b/src/main/java/com/adinstar/pangyo/model/CommentFeedResponse.java
@@ -1,0 +1,15 @@
+package com.adinstar.pangyo.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CommentFeedResponse extends FeedResponse {
+    private List<Long> myList;
+
+    public CommentFeedResponse(List<Comment> commentList, int expactListSize, List<Long> myList) {
+        super(commentList, expactListSize);
+        this.myList = myList;
+    }
+}

--- a/src/main/java/com/adinstar/pangyo/model/PostFeedResponse.java
+++ b/src/main/java/com/adinstar/pangyo/model/PostFeedResponse.java
@@ -1,0 +1,15 @@
+package com.adinstar.pangyo.model;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PostFeedResponse extends FeedResponse {
+    private List<Long> likeList;
+
+    public PostFeedResponse(List<Post> postList, int expactListSize, List<Long> likeList) {
+        super(postList, expactListSize);
+        this.likeList = likeList;
+    }
+}

--- a/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
+++ b/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
@@ -49,7 +49,7 @@ public class CampaignCandidateService {
             pollList = new ArrayList<>();
         }
 
-        return new CampaignCandidateFeedResponse(campaignCandidateList, size, pollList);
+        return new CampaignCandidateFeedResponse(campaignCandidateList, opPage.orElse(DEFAULT_PAGE), size, pollList);
     }
 
     public CampaignCandidate getById(long id) {

--- a/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
+++ b/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
@@ -1,16 +1,20 @@
 package com.adinstar.pangyo.service;
 
+import com.adinstar.pangyo.constant.PangyoEnum;
 import com.adinstar.pangyo.constant.PangyoEnum.CampaignCandidateStatus;
 import com.adinstar.pangyo.constant.PangyoEnum.ExecutionRuleType;
 import com.adinstar.pangyo.controller.exception.UnauthorizedException;
 import com.adinstar.pangyo.mapper.CampaignCandidateMapper;
 import com.adinstar.pangyo.model.CampaignCandidate;
+import com.adinstar.pangyo.model.CampaignCandidateFeedResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class CampaignCandidateService {
@@ -23,14 +27,29 @@ public class CampaignCandidateService {
     @Autowired
     private ExecutionRuleService executionRuleService;
 
+    @Autowired
+    private PollService pollService;
+
     public long getRunningExecuteRuleId() {
         return executionRuleService.getProgressExecuteRuleIdByType(ExecutionRuleType.CANDIDATE);
     }
 
-    public List<CampaignCandidate> getRunningList(long starId, Optional<Integer> opPage, Optional<Integer> opSize) {
+    public CampaignCandidateFeedResponse getRunningList(long starId, Optional<Integer> opPage, Optional<Integer> opSize, Long userId) {
         int size = opSize.orElse(LIST_SIZE);
         int offset = (opPage.orElse(DEFAULT_PAGE) - DEFAULT_PAGE) * size;
-        return campaignCandidateMapper.selectListByStarIdAndExecuteRuleId(starId, getRunningExecuteRuleId(), offset, size);
+
+        List<CampaignCandidate> campaignCandidateList = campaignCandidateMapper.selectListByStarIdAndExecuteRuleId(starId, getRunningExecuteRuleId(), offset, size+1);
+        List<Long> pollList;
+        if (userId != null) {
+            List<Long> ids = campaignCandidateList.stream()
+                    .map(CampaignCandidate::getId)
+                    .collect(Collectors.toList());
+            pollList = pollService.getContentIdList(PangyoEnum.ContentType.CANDIDATE, ids, userId);
+        } else {
+            pollList = new ArrayList<>();
+        }
+
+        return new CampaignCandidateFeedResponse(campaignCandidateList, size, pollList);
     }
 
     public CampaignCandidate getById(long id) {

--- a/src/main/java/com/adinstar/pangyo/service/CommentService.java
+++ b/src/main/java/com/adinstar/pangyo/service/CommentService.java
@@ -3,13 +3,16 @@ package com.adinstar.pangyo.service;
 import com.adinstar.pangyo.constant.PangyoEnum;
 import com.adinstar.pangyo.mapper.CommentMapper;
 import com.adinstar.pangyo.model.Comment;
-import com.adinstar.pangyo.model.FeedResponse;
+import com.adinstar.pangyo.model.CommentFeedResponse;
+import com.adinstar.pangyo.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class CommentService {
@@ -22,9 +25,21 @@ public class CommentService {
 
     private static final int LIST_SIZE = 5;
 
-    public FeedResponse<Comment> getList(PangyoEnum.ContentType contentType, long contentId, Optional lastId) {
-        List<Comment> postList = commentMapper.selectList(contentType, contentId, (long)lastId.orElse(Long.MAX_VALUE), LIST_SIZE+1);
-        return new FeedResponse<>(postList, LIST_SIZE);
+    public CommentFeedResponse getList(PangyoEnum.ContentType contentType, long contentId, Optional lastId, Long userId) {
+        List<Comment> commentList = commentMapper.selectList(contentType, contentId, (long)lastId.orElse(Long.MAX_VALUE), LIST_SIZE+1);
+
+        List<Long> myList;
+        if (userId != null) {
+            myList = commentList.stream()
+                    .map(Comment::getUser)
+                    .map(User::getId)
+                    .filter(id -> userId.equals(id))
+                    .collect(Collectors.toList());
+        } else {
+            myList = new ArrayList<>();
+        }
+
+        return new CommentFeedResponse(commentList, LIST_SIZE, myList);
     }
 
     // TODO: 로그인체크

--- a/src/main/resources/templates/fanClub/campaignCandidate/form.ftl
+++ b/src/main/resources/templates/fanClub/campaignCandidate/form.ftl
@@ -62,7 +62,6 @@
             var type = 'POST';
             var data = getFormData($('form'));
             data.star = {id: ${starId!}};
-            data.user = {id: 1};  // TODO : 실 USER 주입
 
             if (data.useCampaignRandingUrl) {
                 data.randingUrl = '/fanClub/${starId!}/campaign-candidate';

--- a/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
+++ b/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
@@ -21,15 +21,15 @@
         <a href="/fanClub/${starId}/campaign-candidate/write">등록하기</a>
     </div>
 
-    <#if campaignCandidateList?has_content>
+    <#if campaignCandidateFeed?has_content>
     <div id="listSection">
-        <#list campaignCandidateList as campaignCandidate>
+        <#list campaignCandidateFeed.list as campaignCandidate>
             <div style="border: 1px solid; padding: 10px; width:400px">
                 <div class="preview">
                     <div>
                         <label>${campaignCandidate_index+1} ${campaignCandidate.title!}</label>
                         <span>
-                            <@poll.defaultUI polledList?seq_contains(campaignCandidate.id), "CANDIDATE", campaignCandidate.id, campaignCandidate.pollCount />
+                            <@poll.defaultUI campaignCandidateFeed.pollList?seq_contains(campaignCandidate.id), "CANDIDATE", campaignCandidate.id, campaignCandidate.pollCount />
                         </span>
                     </div>
                     <p>${campaignCandidate.body!}</p>

--- a/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
+++ b/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
@@ -14,6 +14,7 @@
 </head>
 <body>
     <@common.importJS />
+    <@poll.defaultScript "CANDIDATE" />
 
     <#include "/fanClub/layout/head.ftl">
     <div style="margin-top:20px">
@@ -29,7 +30,15 @@
                     <div>
                         <label>${campaignCandidate_index+1} ${campaignCandidate.title!}</label>
                         <span>
-                            <@poll.defaultUI campaignCandidateFeed.pollList?seq_contains(campaignCandidate.id), "CANDIDATE", campaignCandidate.id, campaignCandidate.pollCount />
+                            <#if campaignCandidateFeed.pollList?seq_contains(campaignCandidate.id)>
+                                <#assign pollClass="polled">
+                            <#else>
+                                <#assign pollClass="">
+                            </#if>
+                            <a href="javascript:;" class="pollArea ${pollClass!}" onclick="poll(${campaignCandidate.id!}, this);">
+                                투표
+                                <span class="pollCount">${campaignCandidate.pollCount!}</span>
+                            </a>
                         </span>
                     </div>
                     <p>${campaignCandidate.body!}</p>
@@ -47,15 +56,106 @@
             </div>
         </#list>
     </div>
+
+    <div id="endOfListSection"></div>
     </#if>
 
+    <script type="text/template" id="campaign-candidate-detail-template">
+        <div style="border: 1px solid; padding: 10px; width:400px">
+            <div class="preview">
+                <div>
+                    <label><%= rank %> <%= title %></label>
+                    <span>
+                        <%
+                            if (pollList.includes(id)) {
+                                pollClass = "polled";
+                            } else {
+                                pollClass = "";
+                            }
+                        %>
+                        <a href="javascript:;" class="pollArea <%= pollClass %>" onclick="poll(<%= id %>, this);">
+                            투표
+                            <span class="pollCount"><%= pollCount %></span>
+                        </a>
+                    </span>
+                </div>
+                <p><%= body %></p>
+                <p>캠페인 노출 기간 : ${adExecutionRule.startDttm!} ~ ${adExecutionRule.endDttm!}</p>
+                <p>랜딩페이지 url : <%= randingUrl %></p>
+                <p>광고소재 : (TODO 현재 파일명 저장안하고 있음)</p>
+                <% if (bannerImg) { %>
+                    <img src="<%= bannerImg %>" style="max-width: 400px;">
+                <% } %>
+            </div>
+
+            <div class="moreView" style="text-align: center">
+                <button>더보기</button>
+            </div>
+        </div>
+    </script>
+
+    <script src="/js/jquery.visible.js"></script>
     <script type="text/javascript">
-        $(".moreView").click(function () {
+        $(document).ready(function() {
+            $(window).scroll(function(e) {
+                if ($("#endOfListSection").visible(true) && campaignCandidateList.hasMore && !campaignCandidateList.isLoading) {
+                    campaignCandidateList.appendItem();
+                }
+            });
+        });
+
+        var campaignCandidateList = {
+            page: ${campaignCandidateFeed.page!},
+            hasMore: ${campaignCandidateFeed.hasMore!?string},
+            isLoading: false,
+            lastRank: ${campaignCandidateFeed.list!?size},
+
+            appendItem: function() {
+                campaignCandidateList.isLoading = true;
+                campaignCandidateList.getData().then(function(data){
+                    if(data.list == null || data.list.length === 0) {
+                        return;
+                    }
+
+                    var template = _.template($("#campaign-candidate-detail-template").html());
+                    data.list.forEach(function(e, i){
+                        e.pollList = data.pollList;
+                        e.rank = ++campaignCandidateList.lastRank;
+                        $('#listSection').append(template(e));
+                    });
+
+                    campaignCandidateList.page = data.page;
+                    campaignCandidateList.hasMore = data.hasMore;
+                    campaignCandidateList.isLoading = false;
+                });
+            },
+
+            getData: function() {
+                var data = {};
+                if (campaignCandidateList.page != null) {
+                    data.starId = ${star.id!};
+                    data.page = campaignCandidateList.page + 1;
+                }
+
+                return $.ajax({
+                    url : '/api/campaign-candidate',
+                    data : data,
+                    type : 'GET',
+                    success: function(result) {
+                        return result;
+                    },
+                    error: function(res) {
+                        console.log(res);
+                        return {};
+                    }
+                });
+            }
+        };
+
+        $('#listSection').delegate('.moreView', 'click', function () {
             $(this).siblings('.preview').removeClass('preview');
             $(this).remove();
         });
-
-        // TODO : 리스트 더보기 구현
     </script>
 </body>
 </html>

--- a/src/main/resources/templates/fanClub/list.ftl
+++ b/src/main/resources/templates/fanClub/list.ftl
@@ -53,7 +53,7 @@
 
                 <div style="margin-top: 10px;">
                     <span>조회 ${post.viewCount!}</span>
-                    <#if likedList?seq_contains(post.id)>
+                    <#if postFeed.likeList?seq_contains(post.id)>
                         <#assign likeClass="liked">
                     <#else>
                         <#assign likeClass="">
@@ -87,7 +87,14 @@
 
             <div style="margin-top: 10px;">
                 <span>조회 <%= viewCount %></span>
-                <span>좋아요 <%= likeCount %></span>
+                <%
+                    if (likeList.includes(id)) {
+                        likeClass = "liked";
+                    } else {
+                        likeClass = "";
+                    }
+                %>
+                <span class="likeArea <%= likeClass %>">좋아요 <%= likeCount %></span>
                 <span>댓글 <%= commentCount %></span>
                 <a href="/fanClub/${star.id!}/post/<%= id %>">[더 보기]</a>
             </div>
@@ -120,6 +127,7 @@
 
                     var template = _.template($("#post-detail-template").html());
                     data.list.forEach(function(e, i){
+                        e.likeList = data.likeList;
                         $('#listSection').append(template(e));
                     });
 

--- a/src/main/resources/templates/fanClub/post/form.ftl
+++ b/src/main/resources/templates/fanClub/post/form.ftl
@@ -46,7 +46,6 @@
                     id: ${post.id!},
                 </#if>
                 star: {id: ${star.id!}},
-                user: {id:2},  // TODO : 실 USER 주입
                 body: $('#body').val(),
                 img: getImageUrl()
             };

--- a/src/main/resources/templates/macro/comment.ftl
+++ b/src/main/resources/templates/macro/comment.ftl
@@ -11,7 +11,7 @@
                 <div>
                     <strong>${comment.user.name!}</strong>
                     <span>${comment.dateTime.reg!}</span>
-                    <#if comment.user.id == 2> <!-- TODO: 실 user 주입 -->
+                    <#if commentFeed.myList?seq_contains(comment.user.id)>
                         <button id="removeCommentButton" onclick="removeComment(${comment.id!})">삭제</button>
                     </#if>
                 </div>
@@ -31,7 +31,7 @@
             <div>
                 <strong><%= user.name %></strong>
                 <span><%= dateTime.reg %></span>
-                <% if (user.id == 2) { %>  <!-- TODO: 실 user 주입 -->
+                <% if (myList.includes(user.id)) { %>
                     <button id="removeCommentButton" onclick="removeComment(<%= id %>)">삭제</button>
                 <% } %>
             </div>
@@ -99,6 +99,7 @@
 
                     var template = _.template($("#comment-detail-template").html());
                     data.list.forEach(function(e, i){
+                        e.myList = data.myList;
                         $('#commentListSection').append(template(e));
                     });
 

--- a/src/main/resources/templates/macro/comment.ftl
+++ b/src/main/resources/templates/macro/comment.ftl
@@ -45,7 +45,6 @@
             var data = {
                 contentType: "${contentType!}",
                 contentId: ${contentId!},
-                user: {id:2}, // TODO: 실 user 주입
                 body: $('#commentBody').val()
             };
 

--- a/src/main/resources/templates/macro/poll.ftl
+++ b/src/main/resources/templates/macro/poll.ftl
@@ -10,58 +10,48 @@
     </style>
 </#macro>
 
-<#macro defaultUI isPolled, contentType, contentId, count>
-    <#if isPolled>
-        <#assign pollClass="polled">
-    <#else>
-        <#assign pollClass="">
-    </#if>
-    <a href="javascript:;" class="pollArea ${pollClass!}" onclick="poll(${contentId!}, this);">
-        투표
-        <span class="pollCount">${count!}</span>
-    </a>
-
-     <script type="text/javascript">
-        function dontPoll(contentId, $pollArea) {
-            $.ajax({
-                url : '/api/poll/${contentType!}/' + contentId,
-                type : 'DELETE',
-                contentType : "application/json",
-                success: function() {
-                    var $pollCount = $pollArea.find('.pollCount');
-                    $pollCount.text($pollCount.text()*1-1);
-                    $pollArea.removeClass('polled');
-                },
-                error: function(res) {
-                    console.log(res);
-                    alert('투표 취소에 실패했습니다.');
-                }
-            });
-        }
-
-        function doPoll(contentId, $pollArea) {
-            $.ajax({
-                url : '/api/poll/${contentType!}/' + contentId,
-                type : 'POST',
-                contentType : "application/json",
-                success: function() {
-                    var $pollCount = $pollArea.find('.pollCount');
-                    $pollCount.text($pollCount.text()*1+1);
-                    $pollArea.addClass('polled');
-                },
-                error: function(res) {
-                    console.log(res);
-                    alert('투표에 실패했습니다.');
-                }
-            });
-        }
-
-        function poll(contentId, _this) {
-            if ($(_this).hasClass('polled')) {
-                dontPoll(contentId, $(_this));
-            } else {
-                doPoll(contentId, $(_this));
+<#macro defaultScript contentType>
+<script type="text/javascript">
+    function dontPoll(contentId, $pollArea) {
+        $.ajax({
+            url : '/api/poll/${contentType!}/' + contentId,
+            type : 'DELETE',
+            contentType : "application/json",
+            success: function() {
+                var $pollCount = $pollArea.find('.pollCount');
+                $pollCount.text($pollCount.text()*1-1);
+                $pollArea.removeClass('polled');
+            },
+            error: function(res) {
+                console.log(res);
+                alert('투표 취소에 실패했습니다.');
             }
+        });
+    }
+
+    function doPoll(contentId, $pollArea) {
+        $.ajax({
+            url : '/api/poll/${contentType!}/' + contentId,
+            type : 'POST',
+            contentType : "application/json",
+            success: function() {
+                var $pollCount = $pollArea.find('.pollCount');
+                $pollCount.text($pollCount.text()*1+1);
+                $pollArea.addClass('polled');
+            },
+            error: function(res) {
+                console.log(res);
+                alert('투표에 실패했습니다.');
+            }
+        });
+    }
+
+    function poll(contentId, _this) {
+        if ($(_this).hasClass('polled')) {
+            dontPoll(contentId, $(_this));
+        } else {
+            doPoll(contentId, $(_this));
         }
-    </script>
+    }
+</script>
 </#macro>


### PR DESCRIPTION
1. Action(poll, like) 여부를 FeedResponse의 맴버변수로 추가
 - 각 content(cc, post, comment)는 FeedResponse를 상속받아 필요한 Action Object를 맴버변수로 추가하여 사용

2. campaignCandidate list 응답도 FeedResponse 로 제공

3. campaignCandidate front-end에서 더보기 기능 지원 

4. front-end에서 가짜 유저 ID 주입하는 부분 제거
 - api 단에서 viewInfo 세팅은 feature/SCHEDULER 브랜치에서 해주고 있음
 - 따라서 현 상태로 글쓰기(후보, 포스트, 댓글) 기능이 안됨
 - 추후 머지되면 글쓰기 잘 될것임