### PR TITLE
Feature/campaign candidate

### DIFF
--- a/schema/table.sql
+++ b/schema/table.sql
@@ -13,6 +13,13 @@ create table ACTION_HISTORY
 comment '사용자 액션 히스토리'
 ;
 
+create table ACTION_UNIQUE
+(
+	`key` varchar(128) not null
+		primary key
+)
+comment '액션 중복체크' engine=InnoDB
+;
 
 create table CAMPAIGN
 (

--- a/src/main/java/com/adinstar/pangyo/constant/PangyoErrorMessage.java
+++ b/src/main/java/com/adinstar/pangyo/constant/PangyoErrorMessage.java
@@ -12,6 +12,7 @@ public class PangyoErrorMessage {
     public static final String INVALID_PARAM = "유효하지 않은 파라미터 입니다.";
     public static final String DUPLICATE_USER_REGISTER = "이미 가입되어 있습니다.";
     public static final String INVALID_PATH = "유효하지 않은 주소입니다.";
+    public static final String DUPLICATE_POLL = "이미 투표에 참여하였습니다.";
 
     // NotFoundException
     public static final String NOT_FOUND_CAMPAIGN_CANDIDATE = "존재하지 않은 후보군 정보입니다.";

--- a/src/main/java/com/adinstar/pangyo/constant/ViewModelName.java
+++ b/src/main/java/com/adinstar/pangyo/constant/ViewModelName.java
@@ -22,5 +22,6 @@ public class ViewModelName {
 
     public static final String IS_LIKED = "isLiked";
 
+    public static final String CANDIDATE_EXECUTION_RULE = "candidateExecutionRule";
     public static final String AD_EXECUTION_RULE = "adExecutionRule";
 }

--- a/src/main/java/com/adinstar/pangyo/controller/exception/BadRequestException.java
+++ b/src/main/java/com/adinstar/pangyo/controller/exception/BadRequestException.java
@@ -6,6 +6,7 @@ public class BadRequestException extends RuntimeException {
     public static final BadRequestException INVALID_PARAM = new BadRequestException(PangyoErrorMessage.INVALID_PARAM);
     public static final BadRequestException DUPLICATE_USER_REGISTER = new BadRequestException(PangyoErrorMessage.DUPLICATE_USER_REGISTER);
     public static final BadRequestException INVALID_PATH = new BadRequestException(PangyoErrorMessage.INVALID_PATH);
+    public static final BadRequestException DUPLICATE_POLL = new BadRequestException(PangyoErrorMessage.DUPLICATE_POLL);
 
     public BadRequestException(String msg) {
         super(msg);

--- a/src/main/java/com/adinstar/pangyo/controller/view/fanClub/CampaignCandidateController.java
+++ b/src/main/java/com/adinstar/pangyo/controller/view/fanClub/CampaignCandidateController.java
@@ -33,6 +33,7 @@ public class CampaignCandidateController {
                           @ModelAttribute(ViewModelName.VIEWER) ViewerInfo viewerInfo,
                           Model model) {
         model.addAttribute(CAMPAIGN_CANDIDATE_FEED, campaignCandidateService.getRunningList(starId, Optional.empty(), Optional.empty(), viewerInfo == null ? null : viewerInfo.getId()));
+        model.addAttribute(CANDIDATE_EXECUTION_RULE, executionRuleService.getProgressExecuteRuleByType(PangyoEnum.ExecutionRuleType.CANDIDATE));
         model.addAttribute(AD_EXECUTION_RULE, executionRuleService.getAdExecutionRuleByProgressExecuteRuleType(PangyoEnum.ExecutionRuleType.CANDIDATE));
 
         return "fanClub/campaignCandidate/list";

--- a/src/main/java/com/adinstar/pangyo/mapper/ActionHistoryMapper.java
+++ b/src/main/java/com/adinstar/pangyo/mapper/ActionHistoryMapper.java
@@ -4,14 +4,21 @@ import com.adinstar.pangyo.constant.PangyoEnum;
 import com.adinstar.pangyo.model.ActionHistory;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Mapper
+@Repository
 public interface ActionHistoryMapper {
     ActionHistory selectByActionTypeAndContentTypeAndContentIdAndUserId(@Param("actionType") PangyoEnum.ActionType actionType, @Param("contentType") PangyoEnum.ContentType contentType, @Param("contentId") long contentId, @Param("userId") long userId);
     // TODO : 아래 쿼리 풀스캔 안일어나는지 보기
     List<ActionHistory> selectListByActionTypeAndContentTypeAndContentIdsAndUserId(@Param("actionType") PangyoEnum.ActionType actionType, @Param("contentType") PangyoEnum.ContentType contentType, @Param("contentIds") List<Long> contentIds, @Param("userId") long userId);
     int insert(ActionHistory actionHistory);
     int deleteByActionTypeAndContentTypeAndContentIdAndUserId(@Param("actionType") PangyoEnum.ActionType actionType, @Param("contentType") PangyoEnum.ContentType contentType, @Param("contentId") long contentId, @Param("userId") long userId);
+
+    // Action 중복체크를 위한 쿼리
+    String selectFromActionUnique(String key);
+    void insertIntoActionUnique(String key);
+    int deleteFromActionUnique(String key);
 }

--- a/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
+++ b/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
@@ -7,15 +7,13 @@ import java.util.List;
 @Data
 public class CampaignCandidateFeedResponse extends FeedResponse {
     private List<Long> pollList;
-    private List<Long> myList;
     private int page;
 
-    public CampaignCandidateFeedResponse(List<CampaignCandidate> campaignCandidateList, int page, int expactListSize, List<Long> pollList, List<Long> myList) {
+    public CampaignCandidateFeedResponse(List<CampaignCandidate> campaignCandidateList, int page, int expactListSize, List<Long> pollList) {
         super(campaignCandidateList, expactListSize);
 
         this.page = page;
         this.pollList = pollList;
-        this.myList = myList;
 
         // 캠페인후보는 lastId 대신 page값 이용
         this.setLastId(0);

--- a/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
+++ b/src/main/java/com/adinstar/pangyo/model/CampaignCandidateFeedResponse.java
@@ -7,13 +7,15 @@ import java.util.List;
 @Data
 public class CampaignCandidateFeedResponse extends FeedResponse {
     private List<Long> pollList;
+    private List<Long> myList;
     private int page;
 
-    public CampaignCandidateFeedResponse(List<CampaignCandidate> campaignCandidateList, int page, int expactListSize, List<Long> pollList) {
+    public CampaignCandidateFeedResponse(List<CampaignCandidate> campaignCandidateList, int page, int expactListSize, List<Long> pollList, List<Long> myList) {
         super(campaignCandidateList, expactListSize);
 
         this.page = page;
         this.pollList = pollList;
+        this.myList = myList;
 
         // 캠페인후보는 lastId 대신 page값 이용
         this.setLastId(0);

--- a/src/main/java/com/adinstar/pangyo/service/ActionService.java
+++ b/src/main/java/com/adinstar/pangyo/service/ActionService.java
@@ -1,7 +1,6 @@
 package com.adinstar.pangyo.service;
 
 import com.adinstar.pangyo.constant.PangyoEnum;
-import com.adinstar.pangyo.constant.PangyoErrorMessage;
 import com.adinstar.pangyo.controller.exception.NotFoundException;
 import com.adinstar.pangyo.mapper.ActionHistoryMapper;
 import com.adinstar.pangyo.model.ActionHistory;
@@ -57,5 +56,27 @@ public class ActionService {
         if (rc == 0) {
             throw NotFoundException.ACTION_HISTORY;
         }
+    }
+
+    /**************************************************************************************
+     *
+     * Action 중복체크를 위한 메소드
+     *
+     **************************************************************************************/
+
+    public String getUniqueKey(PangyoEnum.ContentType contentType, String postfix) {
+        return String.format("%s_%s_%s", actionType, contentType, postfix);
+    }
+
+    public boolean checkUnique(PangyoEnum.ContentType contentType, String keyPostfix) {
+        return actionHistoryMapper.selectFromActionUnique(getUniqueKey(contentType, keyPostfix)) == null;
+    }
+
+    public void addUnique(PangyoEnum.ContentType contentType, String keyPostfix) {
+        actionHistoryMapper.insertIntoActionUnique(getUniqueKey(contentType, keyPostfix));
+    }
+
+    public void removeUnique(PangyoEnum.ContentType contentType, String keyPostfix) {
+        actionHistoryMapper.deleteFromActionUnique(getUniqueKey(contentType, keyPostfix));
     }
 }

--- a/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
+++ b/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
@@ -48,18 +48,7 @@ public class CampaignCandidateService {
             pollList = new ArrayList<>();
         }
 
-        List<Long> myList;
-        if (userId != null) {
-            myList = campaignCandidateList.stream()
-                    .map(CampaignCandidate::getUser)
-                    .map(User::getId)
-                    .filter(id -> userId.equals(id))
-                    .collect(Collectors.toList());
-        } else {
-            myList = new ArrayList<>();
-        }
-
-        return new CampaignCandidateFeedResponse(campaignCandidateList, opPage.orElse(DEFAULT_PAGE), size, pollList, myList);
+        return new CampaignCandidateFeedResponse(campaignCandidateList, opPage.orElse(DEFAULT_PAGE), size, pollList);
     }
 
     public CampaignCandidate getById(long id) {

--- a/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
+++ b/src/main/java/com/adinstar/pangyo/service/CampaignCandidateService.java
@@ -6,6 +6,7 @@ import com.adinstar.pangyo.constant.PangyoEnum.ExecutionRuleType;
 import com.adinstar.pangyo.mapper.CampaignCandidateMapper;
 import com.adinstar.pangyo.model.CampaignCandidate;
 import com.adinstar.pangyo.model.CampaignCandidateFeedResponse;
+import com.adinstar.pangyo.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -47,7 +48,18 @@ public class CampaignCandidateService {
             pollList = new ArrayList<>();
         }
 
-        return new CampaignCandidateFeedResponse(campaignCandidateList, opPage.orElse(DEFAULT_PAGE), size, pollList);
+        List<Long> myList;
+        if (userId != null) {
+            myList = campaignCandidateList.stream()
+                    .map(CampaignCandidate::getUser)
+                    .map(User::getId)
+                    .filter(id -> userId.equals(id))
+                    .collect(Collectors.toList());
+        } else {
+            myList = new ArrayList<>();
+        }
+
+        return new CampaignCandidateFeedResponse(campaignCandidateList, opPage.orElse(DEFAULT_PAGE), size, pollList, myList);
     }
 
     public CampaignCandidate getById(long id) {

--- a/src/main/java/com/adinstar/pangyo/service/PollService.java
+++ b/src/main/java/com/adinstar/pangyo/service/PollService.java
@@ -48,7 +48,12 @@ public class PollService extends ActionService {
         super.remove(contentType, contentId, userId);
 
         if (PangyoEnum.ContentType.CANDIDATE.equals(contentType)) {
-            removeUnique(contentType, getUniqueKeyPostfix(campaignCandidateService.getById(contentId), userId));
+            CampaignCandidate campaignCandidate = campaignCandidateService.getById(contentId);
+            if (campaignCandidate == null){
+                throw NotFoundException.CAMPAIGN_CANDIDATE;
+            }
+
+            removeUnique(contentType, getUniqueKeyPostfix(campaignCandidate, userId));
             campaignCandidateService.updatePollCount(contentId, -1);
         }
     }

--- a/src/main/resources/mapper/ActionHistoryMapper.xml
+++ b/src/main/resources/mapper/ActionHistoryMapper.xml
@@ -68,4 +68,20 @@
           AND content_id = #{contentId}
           AND user_id = #{userId}
     </delete>
+
+    <!-- // Action 중복체크를 위한 쿼리 -->
+
+    <select id="selectFromActionUnique" parameterType="String" resultType="String">
+        SELECT * FROM ACTION_UNIQUE WHERE `key` = #{key}
+    </select>
+
+    <insert id="insertIntoActionUnique" parameterType="String">
+        INSERT INTO ACTION_UNIQUE (`key`) VALUE (#{key});
+    </insert>
+
+    <delete id="deleteFromActionUnique" parameterType="String">
+        DELETE FROM ACTION_UNIQUE WHERE `key` = #{key}
+    </delete>
+
+    <!-- Action 중복체크를 위한 쿼리 // -->
 </mapper>

--- a/src/main/resources/mapper/ActionHistoryMapper.xml
+++ b/src/main/resources/mapper/ActionHistoryMapper.xml
@@ -76,7 +76,7 @@
     </select>
 
     <insert id="insertIntoActionUnique" parameterType="String">
-        INSERT INTO ACTION_UNIQUE (`key`) VALUE (#{key});
+        INSERT INTO ACTION_UNIQUE (`key`) VALUE (#{key})
     </insert>
 
     <delete id="deleteFromActionUnique" parameterType="String">

--- a/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
+++ b/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
@@ -29,6 +29,9 @@
                 <div class="preview">
                     <div>
                         <label>${campaignCandidate_index+1} ${campaignCandidate.title!}</label>
+                        <#if campaignCandidateFeed.myList?seq_contains(campaignCandidate.user.id)>
+                            <button onclick="removeCampaignCandidate(${campaignCandidate.id!})">삭제</button>
+                        </#if>
                         <span>
                             <#if campaignCandidateFeed.pollList?seq_contains(campaignCandidate.id)>
                                 <#assign pollClass="polled">
@@ -65,6 +68,9 @@
             <div class="preview">
                 <div>
                     <label><%= rank %> <%= title %></label>
+                    <% if (myList.includes(user.id)) { %>
+                        <button onclick="removeCampaignCandidate(<%= id %>)">삭제</button>
+                    <% } %>
                     <span>
                         <%
                             if (pollList.includes(id)) {
@@ -120,6 +126,7 @@
                     var template = _.template($("#campaign-candidate-detail-template").html());
                     data.list.forEach(function(e, i){
                         e.pollList = data.pollList;
+                        e.myList = data.myList;
                         e.rank = ++campaignCandidateList.lastRank;
                         $('#listSection').append(template(e));
                     });
@@ -150,6 +157,25 @@
                 });
             }
         };
+
+        function removeCampaignCandidate(id) {
+            if (!confirm('캠페인 후보를 정말 삭제하시겠습니까?')) {
+                return false;
+            }
+
+            $.ajax({
+                url : '/api/campaign-candidate/' + id,
+                type : 'DELETE',
+                contentType : "application/json",
+                success: function() {
+                    location.reload();
+                },
+                error: function(res) {
+                    console.log(res);
+                    alert('삭제에 실패했습니다.');
+                }
+            });
+        }
 
         $('#listSection').delegate('.moreView', 'click', function () {
             $(this).siblings('.preview').removeClass('preview');

--- a/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
+++ b/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
@@ -34,7 +34,7 @@
                     <div>
                         <label>${campaignCandidate_index+1} ${campaignCandidate.title!}</label>
                         <#if candidateExecutionRule.status == 'RUNNING'>
-                            <#if campaignCandidateFeed.myList?seq_contains(campaignCandidate.user.id)>
+                            <#if viewer?? && campaignCandidate.user?? && viewer.id == campaignCandidate.user.id>
                                 <button onclick="removeCampaignCandidate(${campaignCandidate.id!})">삭제</button>
                             </#if>
                             <span>
@@ -75,7 +75,7 @@
                 <div>
                     <label><%= rank %> <%= title %></label>
                     <#if candidateExecutionRule.status == 'RUNNING'>
-                        <% if (myList.includes(user.id)) { %>
+                        <% if (${viewer???c} && ${viewer.id} == user.id) { %>
                             <button onclick="removeCampaignCandidate(<%= id %>)">삭제</button>
                         <% } %>
                         <span>
@@ -134,7 +134,6 @@
                     var template = _.template($("#campaign-candidate-detail-template").html());
                     data.list.forEach(function(e, i){
                         e.pollList = data.pollList;
-                        e.myList = data.myList;
                         e.rank = ++campaignCandidateList.lastRank;
                         $('#listSection').append(template(e));
                     });

--- a/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
+++ b/src/main/resources/templates/fanClub/campaignCandidate/list.ftl
@@ -19,7 +19,11 @@
     <#include "/fanClub/layout/head.ftl">
     <div style="margin-top:20px">
         <span>NEXT WEEK CAMPAIGN</span>
-        <a href="/fanClub/${star.id}/campaign-candidate/write">등록하기</a>
+        <#if candidateExecutionRule.status == 'RUNNING'>
+            <a href="/fanClub/${star.id}/campaign-candidate/write">등록하기</a>
+        <#else>
+            <strong>투표종료</strong>
+        </#if>
     </div>
 
     <#if campaignCandidateFeed?has_content>
@@ -29,20 +33,22 @@
                 <div class="preview">
                     <div>
                         <label>${campaignCandidate_index+1} ${campaignCandidate.title!}</label>
-                        <#if campaignCandidateFeed.myList?seq_contains(campaignCandidate.user.id)>
-                            <button onclick="removeCampaignCandidate(${campaignCandidate.id!})">삭제</button>
-                        </#if>
-                        <span>
-                            <#if campaignCandidateFeed.pollList?seq_contains(campaignCandidate.id)>
-                                <#assign pollClass="polled">
-                            <#else>
-                                <#assign pollClass="">
+                        <#if candidateExecutionRule.status == 'RUNNING'>
+                            <#if campaignCandidateFeed.myList?seq_contains(campaignCandidate.user.id)>
+                                <button onclick="removeCampaignCandidate(${campaignCandidate.id!})">삭제</button>
                             </#if>
-                            <a href="javascript:;" class="pollArea ${pollClass!}" onclick="poll(${campaignCandidate.id!}, this);">
-                                투표
-                                <span class="pollCount">${campaignCandidate.pollCount!}</span>
-                            </a>
-                        </span>
+                            <span>
+                                <#if campaignCandidateFeed.pollList?seq_contains(campaignCandidate.id)>
+                                    <#assign pollClass="polled">
+                                <#else>
+                                    <#assign pollClass="">
+                                </#if>
+                                <a href="javascript:;" class="pollArea ${pollClass!}" onclick="poll(${campaignCandidate.id!}, this);">
+                                    투표
+                                    <span class="pollCount">${campaignCandidate.pollCount!}</span>
+                                </a>
+                            </span>
+                        </#if>
                     </div>
                     <p>${campaignCandidate.body!}</p>
                     <p>캠페인 노출 기간 : ${adExecutionRule.startDttm!} ~ ${adExecutionRule.endDttm!}</p>
@@ -68,22 +74,24 @@
             <div class="preview">
                 <div>
                     <label><%= rank %> <%= title %></label>
-                    <% if (myList.includes(user.id)) { %>
-                        <button onclick="removeCampaignCandidate(<%= id %>)">삭제</button>
-                    <% } %>
-                    <span>
-                        <%
-                            if (pollList.includes(id)) {
-                                pollClass = "polled";
-                            } else {
-                                pollClass = "";
-                            }
-                        %>
-                        <a href="javascript:;" class="pollArea <%= pollClass %>" onclick="poll(<%= id %>, this);">
-                            투표
-                            <span class="pollCount"><%= pollCount %></span>
-                        </a>
-                    </span>
+                    <#if candidateExecutionRule.status == 'RUNNING'>
+                        <% if (myList.includes(user.id)) { %>
+                            <button onclick="removeCampaignCandidate(<%= id %>)">삭제</button>
+                        <% } %>
+                        <span>
+                            <%
+                                if (pollList.includes(id)) {
+                                    pollClass = "polled";
+                                } else {
+                                    pollClass = "";
+                                }
+                            %>
+                            <a href="javascript:;" class="pollArea <%= pollClass %>" onclick="poll(<%= id %>, this);">
+                                투표
+                                <span class="pollCount"><%= pollCount %></span>
+                            </a>
+                        </span>
+                    </#if>
                 </div>
                 <p><%= body %></p>
                 <p>캠페인 노출 기간 : ${adExecutionRule.startDttm!} ~ ${adExecutionRule.endDttm!}</p>

--- a/src/main/resources/templates/macro/comment.ftl
+++ b/src/main/resources/templates/macro/comment.ftl
@@ -12,7 +12,7 @@
                     <strong>${comment.user.name!}</strong>
                     <span>${comment.dateTime.reg!}</span>
                     <#if commentFeed.myList?seq_contains(comment.user.id)>
-                        <button id="removeCommentButton" onclick="removeComment(${comment.id!})">삭제</button>
+                        <button onclick="removeComment(${comment.id!})">삭제</button>
                     </#if>
                 </div>
 
@@ -32,7 +32,7 @@
                 <strong><%= user.name %></strong>
                 <span><%= dateTime.reg %></span>
                 <% if (myList.includes(user.id)) { %>
-                    <button id="removeCommentButton" onclick="removeComment(<%= id %>)">삭제</button>
+                    <button onclick="removeComment(<%= id %>)">삭제</button>
                 <% } %>
             </div>
 

--- a/src/main/resources/templates/macro/poll.ftl
+++ b/src/main/resources/templates/macro/poll.ftl
@@ -41,7 +41,12 @@
             },
             error: function(res) {
                 console.log(res);
-                alert('투표에 실패했습니다.');
+                res = res.responseJSON;
+                if (res.message) {
+                    alert(res.message);
+                } else {
+                    alert('투표에 실패했습니다.');
+                }
             }
         });
     }

--- a/src/main/resources/templates/star/list.ftl
+++ b/src/main/resources/templates/star/list.ftl
@@ -82,10 +82,10 @@
             <td>
                 <h3><%= content.name %></h3>
                 <span><%= content.fanCount %>fans</span>
-                <button id="joinBotton<%= data.id %>" onclick="joinStar(<%= content.id %>)">+ Join</button>
+                <button id="joinBotton<%= content.id %>" onclick="joinStar(<%= content.id %>)">+ Join</button>
             </td>
             <td style="text-align: center">
-                <img src="<%= data.profileImg %>" style="max-height: 100px">
+                <img src="<%= content.profileImg %>" style="max-height: 100px">
             </td>
         </tr>
     </script>


### PR DESCRIPTION
1. 캠페인 후보 삭제 기능  
 - 내가 등록한 후보인 경우에만 삭제 버튼 노출  
2. (front) 캠페인 후보 투표종료 처리
 - 투표 못함  
 - 후보등록 못함  
 - 후보삭제 못함  
 - TODO : back-end 에서도 제약 걸어줄 필요가 있음 (아직 여기까진 고려 못함)  
3. 투표 중복 체크 추가  
 - 해당 회차에 스타당 1번 투표가능  

투표 중복 체크 시 ACTION_HISTORY 테이블로 투표 중복여부를 확인할 수가 없어서 ACTION_UNIQUE 라는 테이블을 추가했어요. 해당 테이블은 컬럼이 1개예요. 각 액션 별로 unique key를 "잘" 정의해서 액션의 중복을 체크하는 용도예요. 

예를 들어, 캠페인 후보군 투표의 경우 집행룰-스타-유저 3개의 ID 조합이 유일해야해서 해당 3개의 ID를 조합하여 unique key를 만들고, ACTION_UNIQUE 테이블에 key를 PUT 해두고, 추후 중복여부를 확인하는 용도로 사용해요. 

추후 캠페인 무료럽 참여시 중복 체크 용도로도 쓰고 싶어서 제너럴하게 만들어보았어요. 캠페인 무료럽 참여의 경우 집행룰-시간-스타-유저 조합으로 unique key를 만들면 될 것 같은데 이건 상세구현하면서 조합이 바뀔 수도 있을 것 같네요.

해당 중복체크 방식은 unique key를 "잘" 만들어야 하는데, 액션끼리 unique key를 겹치게 만들 수도 있다는 부분이 좀 리스크로 생각되어서요. ActionService를 상속받는 service에서는 단순히 원하는 key조합을 만들고, ActionService에서 key 조합 앞에 ActionType과 ContentType을 붙여줘 각 액션의 key 충돌을 방어해주었어요.

검토해보시고 더 좋은안 있으면 말씀주세요!
특이사항 없을 경우 머지 부탁할께요. 고맙습니다!!